### PR TITLE
feat: implement a countdown widget

### DIFF
--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -51,7 +51,7 @@ class ClacktileApp(App[str]):
         else:
             self.notify(f"Screenshot saved in {saved_filename}")
 
-    def on_typing_area_status_changed(self, message: "TypingArea.StatusChanged"):
+    def on_typing_area_status_changed(self, message: TypingArea.StatusChanged):
         countdown = self.query_one("#timer", expect_type=TimeCountdown)
         match message.status:
             case Status.STARTED:
@@ -59,7 +59,7 @@ class ClacktileApp(App[str]):
             case Status.NOT_STARTED:
                 countdown.reset()
 
-    def on_counter_status_changed(self, status: "TimeCountdown.StatusChanged"):
+    def on_counter_status_changed(self, status: TimeCountdown.StatusChanged):
         typing_area = self.query_one("#input", expect_type=TypingArea)
         if status.status is Status.ENDED:
             typing_area.typing_status = status.status

--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -57,6 +57,8 @@ class ClacktileApp(App[str]):
                 countdown.timer.resume()
             case Status.NOT_STARTED:
                 countdown.reset()
+            case _:
+                pass
 
     def on_counter_status_changed(self, status: TimeCountdown.StatusChanged):
         typing_area = self.query_one("#input", expect_type=TypingArea)

--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -39,7 +39,12 @@ class ClacktileApp(App[str]):
     def action_screenshot(
         self, filename: str | None = None, path: str | None = None
     ) -> None:
-        _ = super().save_screenshot(filename, path)
+        try:
+            saved_filename = super().save_screenshot(filename, path)
+        except Exception:
+            self.notify("Screenshot could not be saved!", severity="warning")
+        else:
+            self.notify(f"Screenshot saved in {saved_filename}")
 
 
 if __name__ == "__main__":

--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -56,7 +56,6 @@ class ClacktileApp(App[str]):
         match message.status:
             case Status.STARTED:
                 countdown.timer.resume()
-                countdown.update_time()
             case Status.NOT_STARTED:
                 countdown.reset()
 

--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -17,7 +17,7 @@ class ClacktileApp(App[str]):
     TITLE = "Clacktile"
     BINDINGS = [
         ("ctrl+l", "next_static_text()", "Next"),
-        ("ctrl+r", "reset_text()", "Reset"),
+        ("ctrl+r", "reset()", "Reset"),
         ("ctrl+s", "screenshot()", "Screenshot"),
     ]
 
@@ -28,15 +28,14 @@ class ClacktileApp(App[str]):
             with Center():
                 yield StaticText(id="text")
             with Container(id="counter"):
-                yield TimeCountdown("00:20", id="timer", start=20)
+                yield TimeCountdown(id="timer", start=10)
             with Center():
                 yield TypingArea(id="input")
 
     def action_next_static_text(self) -> None:
-        self.action_reset_text()
-        self.query_one("#text", expect_type=StaticText).goto_text()
+        self.query_one("#text", expect_type=StaticText).next()
 
-    def action_reset_text(self) -> None:
+    def action_reset(self) -> None:
         _ = self.query_one("#input", expect_type=TypingArea).reset()
         _ = self.query_one("#timer", expect_type=TimeCountdown).reset()
 
@@ -63,6 +62,10 @@ class ClacktileApp(App[str]):
         typing_area = self.query_one("#input", expect_type=TypingArea)
         if status.status is Status.ENDED:
             typing_area.typing_status = status.status
+
+    def on_static_text_changed(self, message: StaticText.Changed):
+        _ = self.action_reset()
+        del message
 
 
 if __name__ == "__main__":

--- a/src/clacktile/__main__.py
+++ b/src/clacktile/__main__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from typing import override
 
 from textual.app import App, ComposeResult
-from textual.containers import Center, Container
-from textual.widgets import TextArea
+from textual.containers import Center, Container, Horizontal
+from textual.widgets import Static, TextArea
 
 from clacktile.static import StaticText
 from clacktile.ui_wrapper import wrap_body
@@ -22,9 +22,11 @@ class ClacktileApp(App[str]):
     @wrap_body(header=True, footer=True)
     @override
     def compose(self) -> ComposeResult:
-        with Container():
+        with Container(id="body"):
             with Center():
                 yield StaticText(id="text")
+            with Container(id="counter"):
+                yield Static("00:30", id="timer")
             with Center():
                 yield TextArea(show_line_numbers=False, id="input")
 

--- a/src/clacktile/common.py
+++ b/src/clacktile/common.py
@@ -1,0 +1,7 @@
+from enum import Enum, auto
+
+
+class Status(Enum):
+    NOT_STARTED = auto()
+    STARTED = auto()
+    ENDED = auto()

--- a/src/clacktile/counter.py
+++ b/src/clacktile/counter.py
@@ -24,12 +24,11 @@ class TimeCountdown(Counter):
         self.timer = self.set_interval(1, self.countdown, pause=True)
         self.start = start
         self.time = start
-        self.reset()
 
     def watch_time(self, time: int):
         if time == 0:
             self.timer.pause()
-            self.post_message(self.StatusChanged(Status.ENDED))
+            _ = self.post_message(self.StatusChanged(Status.ENDED))
         elif time <= 5:
             self.styles.animate("opacity", value=0.2, final_value=1.0, duration=0.9)
             self.styles.animate("color", value="red", duration=4.0)
@@ -43,7 +42,7 @@ class TimeCountdown(Counter):
     def reset(self):
         self.timer.reset()
         self.timer.pause()
-        self.post_message(self.StatusChanged(Status.NOT_STARTED))
+        _ = self.post_message(self.StatusChanged(Status.NOT_STARTED))
         self.time = self.start
         self.renderable = self.construct_renderable(self.start)
         self.styles.reset()

--- a/src/clacktile/counter.py
+++ b/src/clacktile/counter.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from rich.console import RenderableType
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static
@@ -17,38 +16,38 @@ class Counter(Static):
 
 
 class TimeCountdown(Counter):
-    time = reactive(1)
+    time = reactive(0, init=False)
 
-    def __init__(
-        self, renderable: RenderableType, *, start: int, id: str | None = None
-    ) -> None:
+    def __init__(self, *, start: int, id: str | None = None) -> None:
+        renderable = self.construct_renderable(start)
         super().__init__(renderable, id=id)
-        self.timer = self.set_interval(1, self.update_time, pause=True)
+        self.timer = self.set_interval(1, self.countdown, pause=True)
         self.start = start
         self.time = start
-        self.init = self.renderable
+        self.reset()
 
     def watch_time(self, time: int):
         if time == 0:
             self.timer.pause()
             self.post_message(self.StatusChanged(Status.ENDED))
-        elif time == self.start:
-            self.timer.pause()
-            self.post_message(self.StatusChanged(Status.NOT_STARTED))
+        elif time <= 5:
+            self.styles.animate("opacity", value=0.2, final_value=1.0, duration=0.9)
+            self.styles.animate("color", value="red", duration=4.0)
 
-    def update_time(self):
-        if self.time > 0:
-            self.time -= 1
+    def countdown(self):
+        self.time -= 1
         minutes, seconds = divmod(self.time, 60)
         updated_time = f"{minutes:02d}:{seconds:02d}"
-        if 0 < self.time < 5:
-            updated_time = f"[blink red]{updated_time}"
-        elif self.time == 0:
-            updated_time = f"[red]{updated_time}"
         self.update(updated_time)
 
     def reset(self):
         self.timer.reset()
         self.timer.pause()
+        self.post_message(self.StatusChanged(Status.NOT_STARTED))
         self.time = self.start
-        self.renderable = self.init
+        self.renderable = self.construct_renderable(self.start)
+        self.styles.reset()
+
+    @staticmethod
+    def construct_renderable(start: int) -> str:
+        return f"00:{start}"

--- a/src/clacktile/counter.py
+++ b/src/clacktile/counter.py
@@ -1,16 +1,53 @@
-from dataclasses import dataclass
-from enum import Enum, auto
+from __future__ import annotations
 
+from dataclasses import dataclass
+
+from rich.console import RenderableType
+from textual.message import Message
+from textual.reactive import reactive
 from textual.widgets import Static
 
-
-class Status(Enum):
-    NOT_STARTED = auto()
-    STARTED = auto()
-    ENDED = auto()
+from clacktile.common import Status
 
 
 class Counter(Static):
     @dataclass
-    class StatusChanged:
+    class StatusChanged(Message):
         status: Status
+
+
+class TimeCountdown(Counter):
+    time = reactive(1)
+
+    def __init__(
+        self, renderable: RenderableType, *, start: int, id: str | None = None
+    ) -> None:
+        super().__init__(renderable, id=id)
+        self.timer = self.set_interval(1, self.update_time, pause=True)
+        self.start = start
+        self.time = start
+        self.init = self.renderable
+
+    def watch_time(self, time: int):
+        if time == 0:
+            self.timer.pause()
+            self.post_message(self.StatusChanged(Status.ENDED))
+        elif time == self.start:
+            self.timer.pause()
+            self.post_message(self.StatusChanged(Status.NOT_STARTED))
+
+    def update_time(self):
+        if self.time > 0:
+            self.time -= 1
+        minutes, seconds = divmod(self.time, 60)
+        updated_time = f"{minutes:02d}:{seconds:02d}"
+        if 0 < self.time < 5:
+            updated_time = f"[blink red]{updated_time}"
+        elif self.time == 0:
+            updated_time = f"[red]{updated_time}"
+        self.update(updated_time)
+
+    def reset(self):
+        self.timer.reset()
+        self.time = self.start
+        self.renderable = self.init

--- a/src/clacktile/counter.py
+++ b/src/clacktile/counter.py
@@ -49,5 +49,6 @@ class TimeCountdown(Counter):
 
     def reset(self):
         self.timer.reset()
+        self.timer.pause()
         self.time = self.start
         self.renderable = self.init

--- a/src/clacktile/counter.py
+++ b/src/clacktile/counter.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+
+from textual.widgets import Static
+
+
+class Status(Enum):
+    NOT_STARTED = auto()
+    STARTED = auto()
+    ENDED = auto()
+
+
+class Counter(Static):
+    @dataclass
+    class StatusChanged:
+        status: Status

--- a/src/clacktile/input.py
+++ b/src/clacktile/input.py
@@ -20,7 +20,6 @@ class TypingArea(TextArea):
         super().__init__(text, show_line_numbers=False, id=id)
 
     def reset(self):
-        _ = self.clear()
         self.typing_status = Status.NOT_STARTED
 
     def on_key(self, key: Key):
@@ -35,3 +34,5 @@ class TypingArea(TextArea):
             case Status.ENDED:
                 # TODO: Consider cursor visibility
                 self.read_only = True
+            case Status.NOT_STARTED:
+                _ = self.clear()

--- a/src/clacktile/input.py
+++ b/src/clacktile/input.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from textual.events import Key
+from textual.message import Message
+from textual.reactive import reactive
+from textual.widgets import TextArea
+
+
+class Status(Enum):
+    NOT_STARTED = auto()
+    STARTED = auto()
+    ENDED = auto()
+
+
+class TypingArea(TextArea):
+    typing_status = reactive(Status.NOT_STARTED)
+
+    @dataclass
+    class StatusChanged(Message):
+        status: Status
+
+    def __init__(self, text: str = "", *, id: str | None = None) -> None:
+        super().__init__(text, show_line_numbers=False, id=id)
+
+    def reset(self):
+        _ = self.clear()
+        self.typing_status = Status.NOT_STARTED
+
+    def on_key(self, key: Key):
+        if key.is_printable and self.typing_status is Status.NOT_STARTED:
+            self.typing_status = Status.STARTED
+
+    def on_counter_status_changed(self, status: str):
+        if status == "ended":
+            self.typing_status = Status.ENDED
+
+    def watch_typing_status(self, status: Status):
+        match status:
+            case Status.STARTED:
+                _ = self.post_message(TypingArea.StatusChanged(status))
+            case Status.ENDED:
+                _ = self.post_message(TypingArea.StatusChanged(status))
+                self.read_only = True
+            case _:
+                pass

--- a/src/clacktile/input.py
+++ b/src/clacktile/input.py
@@ -1,17 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum, auto
 from textual.events import Key
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import TextArea
 
-
-class Status(Enum):
-    NOT_STARTED = auto()
-    STARTED = auto()
-    ENDED = auto()
+from clacktile.common import Status
 
 
 class TypingArea(TextArea):
@@ -32,16 +27,11 @@ class TypingArea(TextArea):
         if key.is_printable and self.typing_status is Status.NOT_STARTED:
             self.typing_status = Status.STARTED
 
-    def on_counter_status_changed(self, status: str):
-        if status == "ended":
-            self.typing_status = Status.ENDED
-
     def watch_typing_status(self, status: Status):
         match status:
             case Status.STARTED:
                 _ = self.post_message(TypingArea.StatusChanged(status))
+                self.read_only = False
             case Status.ENDED:
-                _ = self.post_message(TypingArea.StatusChanged(status))
+                # TODO: Consider cursor visibility
                 self.read_only = True
-            case _:
-                pass

--- a/src/clacktile/static.py
+++ b/src/clacktile/static.py
@@ -2,7 +2,7 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static
 
-from clacktile.textloader import load_text
+from clacktile.textloader import SavedTexts
 
 
 class StaticText(Static, can_focus=True):
@@ -12,9 +12,9 @@ class StaticText(Static, can_focus=True):
         pass
 
     def __init__(self, id: str) -> None:
-        super().__init__(renderable=load_text(0), id=id)
+        super().__init__(renderable=SavedTexts.load(0), id=id)
 
     def next(self) -> None:
         self.count += 1
-        self.renderable = load_text(self.count)
-        self.post_message(self.Changed())
+        self.renderable = SavedTexts.load(self.count)
+        _ = self.post_message(self.Changed())

--- a/src/clacktile/static.py
+++ b/src/clacktile/static.py
@@ -1,3 +1,4 @@
+from textual.message import Message
 from textual.reactive import reactive
 from textual.widgets import Static
 
@@ -7,10 +8,13 @@ from clacktile.textloader import load_text
 class StaticText(Static, can_focus=True):
     count = reactive(0)
 
+    class Changed(Message):
+        pass
+
     def __init__(self, id: str) -> None:
         super().__init__(renderable=load_text(0), id=id)
 
-    def goto_text(self) -> None:
-        print("action go to next ########")
+    def next(self) -> None:
         self.count += 1
         self.renderable = load_text(self.count)
+        self.post_message(self.Changed())

--- a/src/clacktile/style/layers.tcss
+++ b/src/clacktile/style/layers.tcss
@@ -3,12 +3,12 @@ Screen {
     layers: below above;
 }
 
-Container {
+#body {
   content-align: center middle;
   text-align: center;
 }
 
-Static {
+StaticText {
     width: 28;
     height: 8;
     color: auto;
@@ -29,5 +29,17 @@ TextArea {
     width: 60%;
     height: 60%;
     background: teal 0%;
-    margin-top: 2;
+    margin-top: 0;
+}
+
+#counter {
+  width: 80%;
+  content-align: right middle;
+  text-align: right;
+  padding: 1;
+}
+
+#timer {
+  dock: bottom;
+  content-align: right middle;
 }

--- a/src/clacktile/style/layers.tcss
+++ b/src/clacktile/style/layers.tcss
@@ -25,7 +25,7 @@ StaticText {
     height: 10;
 }
 
-TextArea {
+TypingArea {
     width: 60%;
     height: 60%;
     background: teal 0%;

--- a/src/clacktile/textloader.py
+++ b/src/clacktile/textloader.py
@@ -1,31 +1,35 @@
 from pathlib import Path
+from types import MappingProxyType
 from typing import Final, final
+
+
+ERROR_HANDLERS: Final[MappingProxyType[type[Exception], str]] = MappingProxyType(
+    {
+        ZeroDivisionError: "No file available!",
+        PermissionError: "Permission denied! Make sure you have read permission.",
+        ValueError: "Can't decode encoding!",
+    }
+)
 
 
 @final
 class SavedTexts:
-    SAVED_TEXT_PATH: Final[Path] = Path(__file__).parent / "saved"
-    _files = tuple(SAVED_TEXT_PATH.glob("*.txt"))
+    PATH: Final[Path] = Path(__file__).parent / "saved"
+    _files = tuple(PATH.glob("*.txt"))
     _num_files = len(_files)
 
     @classmethod
     def refresh(cls):
-        cls._files = tuple(cls.SAVED_TEXT_PATH.glob("*.txt"))
+        cls._files = tuple(cls.PATH.glob("*.txt"))
         cls._num_files = len(cls._files)
 
     @classmethod
-    def get(cls, index: int) -> str:
-        return cls._files[index % len(cls._files)].read_text(
-            encoding="ascii", errors="strict"
-        )
-
-
-def load_text(index: int) -> str:
-    try:
-        return SavedTexts.get(index)
-    except (IndexError, ZeroDivisionError):
-        return "No file available!"
-    except ValueError:
-        return "Can't decode encoding!"
-    except PermissionError:
-        return "Permission denied. Make sure you have read permission."
+    def load(cls, index: int) -> str:
+        try:
+            index %= cls._num_files
+            return cls._files[index].read_text(encoding="ascii", errors="strict")
+        except Exception as e:
+            msg = ERROR_HANDLERS.get(type(e))
+            if msg is None:
+                raise
+            return msg


### PR DESCRIPTION
- countdown widget that counts down from a specific set time, to zero, updating the counter display every second.
- When there is 5 seconds left, display starts blinking red.
- When the countdown has reached 0, typing area becomes read only.
- When app is reset, the countdown resets to its initial state.
- When static text is changed, countdown is reset.

resolves #3 