### PR TITLE
fix: text-area statys read-only after reload

### DIFF
--- a/src/clacktile/input.py
+++ b/src/clacktile/input.py
@@ -52,3 +52,4 @@ class TypingArea(TextArea):
                 _ = self.post_message(self.StatusChanged(Status.ENDED, text=self.text))
             case Status.NOT_STARTED:
                 _ = self.clear()
+                self.read_only = False


### PR DESCRIPTION
This commit resets read-only status on reset.